### PR TITLE
Next and (hopefully) final draft of SRFI 136

### DIFF
--- a/srfi-136.html
+++ b/srfi-136.html
@@ -17,7 +17,15 @@ Extensible record types
 
 <H1>Status</H1>
 
-<p>This SRFI is currently in <em>draft</em> status. Here is <a href="http://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+136+at+srfi+dotschemers+dot+org">srfi-136@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="http://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="http://srfi-email.schemers.org/srfi-136">archive</a>.</p>
+<p>This SRFI is currently in <em>draft</em> status. Here
+is <a href="http://srfi.schemers.org/srfi-process.html">an
+explanation</a> of each status that a SRFI can hold.  To provide input
+on this SRFI, please send email
+to <code><a href="mailto:srfi+minus+136+at+srfi+dotschemers+dot+org">srfi-136@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.
+To subscribe to the list,
+follow <a href="http://srfi.schemers.org/srfi-list-subscribe.html">these
+instructions</a>.  You can access previous messages via the mailing
+list <a href="http://srfi-email.schemers.org/srfi-136">archive</a>.</p>
 <ul>
   <li>Received: 2016/6/23</li>
   <li>60-day deadline: 2016/8/23</li>
@@ -114,15 +122,18 @@ the record type has to be defined and used.
 </ul>
 
 <p>
-This specification also provides a minimal procedural interface and very basic
-introspection facilities, on which more sophisticated systems like the one
-specified by SRFI 99 can be built. R7RS leaves it open whether the record type
-descriptor is bound by a record-type definition to a runtime object or a syntactic
-representation. In order to be able to provide introspection facilities already
-at the expansion level, in this specification the choice of a syntactic representation
-as a keyword has been made. Due to this choice, the record type descriptor cannot serve
-as a descriptor for the record type in the procedural interface. The record-type predicate,
-which also uniquely describes a record-type, is used in the procedural interface instead.
+This specification also provides a minimal procedural interface and
+very basic introspection facilities, on which more sophisticated
+systems like the one specified by SRFI 99 can be built. R7RS leaves it
+open whether the record type descriptor is bound by a record-type
+definition to a runtime object or a syntactic representation. In order
+to be able to provide introspection facilities already at the
+expansion level, in this specification the choice of a syntactic
+representation as a keyword has been made. Due to this choice, the
+record type descriptor cannot serve as a descriptor for the record
+type in the procedural interface.  However, a <em>runtime record-type
+descriptor</em> can be extracted from the keyword to be used in the
+procedural interface.
 </p>
 
 <h1>Specification</h1>
@@ -170,6 +181,7 @@ This SRFI extends 7.1.6 of R7RS-small as follows:
                     -&gt; #f
  
  &lt;macro use&gt;        -&gt; (&lt;type name&gt; (&lt;keyword&gt; &lt;datum&gt; ...))
+                    -&gt; (&lt;type name&gt;)
 </pre>
 
 <p>
@@ -191,8 +203,8 @@ This SRFI extends 7.1.6 of R7RS-small as follows:
   <li>defines an accessor for each field name;</li>
   <li>defines a mutator for each mutable field name</li>
 </ul>
-<p>The predicate (if defined) also serves as a placeholder for the record-type in the
-  procedural interface defined below.</p>
+<p>From the keyword that is bound to the record-type descriptor, a runtime representation for the
+  use in procedural interface defined below can be extracted.</p>
 
 <p>
 A record type definition extends R7RS-small with the following additional options:
@@ -248,6 +260,9 @@ Then the macro use <code>(&lt;type name&gt;
 </pre>
 (If the record-type does not have a parent, <code>&lt;parent&gt;</code> is <code>#f</code>.)
 </p>
+Furthermore, the macro use <code>(&lt;type name&gt;)</code>
+macro-expands into an object that serves as a runtime record-type
+descriptor for the procedural interface (see below).
 
 <h2>Procedures</h2>
 
@@ -263,34 +278,56 @@ The following set of procedures is defined:
 </p>
 
 <p>
-  <code>(record-type-predicate <em>record</em>)</code>
+  <code>(record-type-descriptor? <em>obj</em>)</code>
 </p>
 
 <p>
-  Returns the type predicate of the record type of the record <code><em>record</em></code>
-  or <code>#f</code> if none is defined.
+  Returns <code>#t</code> if and only if <code><em>obj</em></code> is
+  a runtime record-type descriptor.
 </p>
 
 <p>
-  <code>(record-type-name <em>predicate</em>)</code>
+  <code>(record-type descriptor <em>record</em>)</code>
 </p>
 
 <p>
-  Returns the name of the record-type, for which <code><em>predicate</em></code> is the type
-  predicate, as a symbol.
+  Returns the runtime record-type descriptor of the record type of the
+  record <code></em>record</em></code>.
 </p>
 
 <p>
-  <code>(record-type-parent <em>predicate</em>)</code>
+  <code>(record-type-predicate <em>rtd</em>)</code>
 </p>
 
 <p>
-  Returns the type predicate of the parent of the record-type, for which
-  <code><em>predicate</em></code> is the type predicate, or <code>#f</code> if there is no parent.
+  Returns the type predicate of the record type, for
+  which <code><em>rtd</em></code> is the runtime record-type
+  descriptor.
 </p>
 
 <p>
-  <code>(record-type-fields <em>predicate</em>)</code>
+  <code>(record-type-name <em>rtd</em>)</code>
+</p>
+
+<p>
+  Returns the name of the record-type, for
+  which <code><em>rtd</em></code> is the runtime record-type
+  descriptor, as a symbol.
+</p>
+
+<p>
+  <code>(record-type-parent <em>rtd</em>)</code>
+</p>
+
+<p>
+  Returns the runtime record-type descriptor of the parent of the
+  record-type, for which
+  <code><em>rtd</em></code> is the runtime record-type descriptor,
+  or <code>#f</code> if there is no parent.
+</p>
+
+<p>
+  <code>(record-type-fields <em>rtd</em>)</code>
 </p>
 
 <p>
@@ -298,7 +335,7 @@ The following set of procedures is defined:
   form <code>(<em>field-name</em> <em>accessor</em> <em>mutator</em>)</code>
   corresponding to the fields (excluding those of parent record-types)
   defined by the record-type, for
-  which <code><em>predicate</em></code> is the type predicate, such
+  which <code><em>rtd</em></code> is the runtime record-type descriptor, such
   that:
   <ul>
     <li><code><em>field name</em></code> is the name of the field as a symbol or
@@ -310,42 +347,46 @@ The following set of procedures is defined:
 </p>
 
 <p>
-  <code>(make-record-type-predicate <em>name</em> <em>fieldspecs</em>)</code>
+  <code>(make-record-type-descriptor <em>name</em> <em>fieldspecs</em>)</code>
 <p>
 
 <p>
-  <code>(make-record-type-predicate <em>name</em> <em>fieldspecs</em> <em>parent</em>)</code>
+  <code>(make-record-type-descriptor <em>name</em> <em>fieldspecs</em> <em>parent</em>)</code>
 <p>
   
 <p>
-  If <code><em>name</em></code> evaluates to a symbol <code>'&lt;type name&gt;</code>
-  and <code><em>parent</em></code> evaluates to the type predicate of a record type definition of
+  If <code><em>name</em></code> evaluates to a symbol <code>'&lt;type
+  name&gt;</code> and <code><em>parent</em></code> evaluates to the
+  runtime record-type descriptor of a record type definition of
   <code>&lt;parent&gt;</code> (if the argument <code><em>parent</em></code> is omitted,
   <code>&lt;parent&gt;</code> defaults to <code>#f</code>),  
   and <code><em>fieldspecs</em></code> evaluates to a list <code>'(&lt;field spec&gt; ...)</code>,
   the application
-  <code>(make-record-type-predicate <em>name</em> <em>fieldspecs</em> <em>parent</em>)</code>
+  <code>(make-record-type-descriptor <em>name</em> <em>fieldspecs</em> <em>parent</em>)</code>
   evaluates to
 <pre>
  (let ()
    (define-record-type (&lt;type name&gt; &lt;parent&gt;)
      #f
-     predicate
+     #f
      &lt;field spec&gt; ...)
-   predicate)
+   (&lt;type name&gt;))
 </pre>
-where the accessor and mutator names (if any) are effectively renamed to make them unique.
-Note that the newly bound predicate differs from any existing record-type predicate.
+where the accessor and mutator names (if any) are effectively renamed
+to make them unique.  Note that the newly bound runtime record type
+descriptor differs from any existing runtime record-type descriptor.
 </p>
 
 <p>
-  <code>(make-record <em>predicate</em> <em>field-vector</em>)</code>
+  <code>(make-record <em>rtd</em> <em>field-vector</em>)</code>
 <p>
 
 <p>
-  Returns an instance of the record type, for which <code><em>predicate</em></code> is the
-  record-type predicate, whose fields (including those of parent record-types with the fields of
-  parent record-types coming first) are initialized with the objects in the vector
+  Returns an instance of the record type, for
+  which <code><em>rtd</em></code> is the runtime record-type
+  descriptor, whose fields (including those of parent record-types
+  with the fields of parent record-types coming first) are initialized
+  with the objects in the vector
   <em>field-vector</em> in order. It is an error if the <em>field-vector</em> does not have as
   many elements as there are fields. It is unspecified whether the vector is shared with
   the newly created record.

--- a/srfi/131.scm
+++ b/srfi/131.scm
@@ -20,6 +20,11 @@
 ;; CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 ;; SOFTWARE.
 
+(define-syntax rtd
+  (syntax-rules ()
+    ((rtd (<child> <parent>)) (<child>))
+    ((rtd <record>) (<record>))))
+
 (define-syntax define-record-type
   (syntax-rules ()
     ((_ type-spec constructor-spec
@@ -36,7 +41,7 @@
        (define-record-type/136 type-spec constructor-name/136
 	 predicate-spec (field accessor . mutator*) ...)
        (define constructor-name
-	 (make-constructor/131 predicate-spec
+	 (make-constructor/131 (rtd type-spec)
 			       '(field-name ...)))))
     ((_ type-spec constructor-name
 	predicate-spec (field accessor . mutator*) ...)
@@ -44,14 +49,14 @@
        (define-record-type/136 type-spec constructor-name/136
 	 predicate-spec (field accessor . mutator*) ...)
        (define constructor-name
-	 (make-constructor/131 predicate-spec #f))))))
+	 (make-constructor/131 (rtd type-spec) #f))))))
 
-(define (make-constructor/131 predicate field-names)
+(define (make-constructor/131 rtd field-names)
   (if field-names
-      (let loop ((p predicate) (fields '()))
-	(if p
-	    (loop (record-type-parent p)
-		  (append (map car (record-type-fields p)) fields))
+      (let loop ((r rtd) (fields '()))
+	(if r
+	    (loop (record-type-parent r)
+		  (append (map car (record-type-fields r)) fields))
 	    (let ((indices
 		   (map (lambda (field-name)
 			  (let loop ((fields fields) (index 0))
@@ -70,6 +75,6 @@
 		  (for-each (lambda (arg index)
 			      (vector-set! field-vector index arg))
 			    args indices)
-		  (make-record predicate field-vector))))))
+		  (make-record rtd field-vector))))))
       (lambda args
-	(make-record predicate (list->vector args)))))
+	(make-record rtd (list->vector args)))))

--- a/srfi/136.sld
+++ b/srfi/136.sld
@@ -22,7 +22,8 @@
 
 (define-library (srfi 136)
   (import (rename (scheme base)
-		  (define-record-type scheme-define-record-type)))
+		  (define-record-type scheme-define-record-type))
+	  (srfi 137))
   (export define-record-type
 	  record-type-descriptor?
 	  record?

--- a/srfi/136.sld
+++ b/srfi/136.sld
@@ -24,12 +24,14 @@
   (import (rename (scheme base)
 		  (define-record-type scheme-define-record-type)))
   (export define-record-type
+	  record-type-descriptor?
 	  record?
+	  record-type-descriptor
 	  record-type-predicate
 	  record-type-name
 	  record-type-parent
 	  record-type-fields
-	  make-record-type-predicate
+	  make-record-type-descriptor
 	  make-record)
   (include "136.scm"))
 

--- a/srfi/136/test.sld
+++ b/srfi/136/test.sld
@@ -142,6 +142,13 @@
 				  (<record> (k))))
 		      (list field-symbol (accessor record)))))
 
+      (test-assert "Runtime record-type descriptors"
+	           (let ()
+                     (define-record-type <record>
+		       (make-foo)
+		       foo?)
+		     (record-type-descriptor? (<record>))))
+	  
       (test-equal "Predicate for records"
 		  '(#t #f)
 		  (let ()
@@ -151,12 +158,19 @@
 		    (list (record? (make-foo))
 			  (record? (vector)))))
 
+      (test-assert "Runtime record-type descriptor from instance"
+                   (let ()
+		     (define-record-type <record>
+		       (make-record)
+			record?)
+		     (eq? (record-type-descriptor (make-record)) (<record>))))
+	        
       (test-assert "Record-type predicate"
 		   (let ()
 		     (define-record-type <record>
 		       (make-record)
 		       record?)
-		     (eq? (record-type-predicate (make-record)) record?)))
+		     (eq? (record-type-predicate (<record>)) record?)))
 		   
       (test-equal "Introspection of record-type name"
 		  '<record>
@@ -164,7 +178,7 @@
 		    (define-record-type <record>
 		      (make-record)
 		      record?)
-		    (record-type-name record?)))
+		    (record-type-name (<record>))))
 
       (test-assert "Introspection of record-type parent"
 		   (let ()
@@ -174,7 +188,7 @@
 		     (define-record-type (<child> <parent>)
 		       #f
 		       child?)
-		     (eq? (record-type-parent child?) parent?)))
+		     (eq? (record-type-parent (<child>)) (<parent>))))
 
       (test-equal "Introspection of record-type fields"
 		  '(foo 2)
@@ -185,7 +199,7 @@
 		      (foo foo)
 		      (bar bar set-bar!))
 		    (define-values (field-foo field-bar)
-		      (apply values (record-type-fields record?)))
+		      (apply values (record-type-fields (<record>))))
 		    (define record (make-record 1))
 		    ((list-ref field-bar 2) record 2)
 		    (list (list-ref field-foo 0) (bar record))))
@@ -197,11 +211,11 @@
 		      #f
 		      parent?
 		      (bar bar))
-		    (define child? (make-record-type-predicate '<child>
-							       '((foo foo))
-							       parent?))
-		    (define child (make-record child? #(1 2)))
-		    (define foo (list-ref (car (record-type-fields child?)) 1))
+		    (define child-rtd (make-record-type-descriptor '<child>
+								   '((foo foo))
+								   (<parent>)))
+		    (define child (make-record child-rtd #(1 2)))
+		    (define foo (list-ref (car (record-type-fields child-rtd)) 1))
 		    (list (parent? child)
 			  (bar child)
 			  (foo child))))

--- a/srfi/136/test.sld
+++ b/srfi/136/test.sld
@@ -231,5 +231,5 @@
 		      (d bar-b))
 		    (define record (make-bar 1 2 3 4))
 		    (list (bar? record) (bar-a record) (bar-b record))))
-		  
+
       (test-end "Extensible record types"))))

--- a/srfi/137.scm
+++ b/srfi/137.scm
@@ -1,0 +1,32 @@
+(define-record-type <instance>
+  (make-instance ancestors payload)
+  instance?
+  (ancestors instance-ancestors)
+  (payload instance-payload))
+
+(define (%make-type proper-ancestors payload)
+  (define (type-accessor . rest)
+    (if (null? rest)
+	payload
+	ancestors))
+  (define (constructor payload)
+    (make-instance ancestors payload))
+  (define (predicate object)
+    (and (instance? object)
+	 (memq constructor (instance-ancestors object))
+	 #t))
+  (define (accessor object)
+    (unless (predicate object)
+      (error "not an instance of the correct type" object))
+    (instance-payload object))
+  (define (make-subtype payload)
+    (%make-type ancestors payload))
+  (define ancestors (cons constructor proper-ancestors))
+  (values type-accessor
+	    constructor
+	    predicate
+	    accessor
+	    make-subtype))
+
+(define (make-type payload)
+  (%make-type '() payload))

--- a/srfi/137.sld
+++ b/srfi/137.sld
@@ -1,0 +1,4 @@
+(define-library (srfi 137)
+  (export make-type)
+  (import (scheme base))
+  (include "137.scm"))


### PR DESCRIPTION
This draft incorporates two important changes:
1. The concept of a runtime record-type descriptor is being introduced.
   
   In previous iterations of this proposal, the predicate procedure
   of a record type served a second purpose, namely that of a runtime
   representaton of the record type descriptor to be used in the
   procedural interface. This led to some misunderstandings and a
   couple of questions raised in
   http://srfi-email.schemers.org/srfi-136/msg/4000979. These
   questions have been addressed in this modification of the proposal,
   which introduces the notion of a runtime record-type descriptor, which
   can be extracted from the (syntactic) record-type descriptor and
   which frees the record-type predicate from having to serve two purposes.
2. The implementation of SRFI 136 is now being based on top of SRFI 137 (whose sample implementation has been included in the repository). This is mainly in order to demonstrate how to use SRFI 137 and how SRFI 136 could be implemented on the primitives provided by SRFI 137.
